### PR TITLE
docs: fix apostrophe

### DIFF
--- a/What_are_BRC20_tokens_(explainCKBot)/index.md
+++ b/What_are_BRC20_tokens_(explainCKBot)/index.md
@@ -2,7 +2,7 @@
 title: 'What are BRC-20 Tokens?'
 coverImage: 'images/image1.png'
 category:
-subtitle: Embarking on a journey into the heart of Bitcoin's innovative landscape introduces us to the burgeoning world of BRC-20 tokens, a recent breakthrough that challenges our traditional perceptions of Bitcoin's capabilities.
+subtitle: Embarking on a journey into the heart of Bitcoin’s innovative landscape introduces us to the burgeoning world of BRC-20 tokens, a recent breakthrough that challenges our traditional perceptions of Bitcoin’s capabilities.
 date: '2024-05-14T13:00:00.000Z'
 author:
 - github:explainCKBot


### PR DESCRIPTION
An [apostrophe](http://en.wikipedia.org/wiki/Apostrophe) should be used in [possessive case](http://en.wikipedia.org/wiki/Possessive_case), while [single quotes](http://en.wikipedia.org/wiki/Single_quotes#Quotations_and_speech) are only used around words

Ref: https://english.stackexchange.com/questions/36046/apostrophe-vs-single-quote